### PR TITLE
Fix seed IDs to reset back to 1 whenever we reseed

### DIFF
--- a/backend/src/seeds/populate_ingredients_table.ts
+++ b/backend/src/seeds/populate_ingredients_table.ts
@@ -1,9 +1,15 @@
 import { Knex } from 'knex';
 
 export async function seed(knex: Knex): Promise<void> {
-  // Deletes ALL existing entries
+  
   await knex('ingredients').del();
+  // reset the auto incrementing id
+  await knex.raw('TRUNCATE TABLE ingredients RESTART IDENTITY CASCADE')
+
   await knex('recipes').del();
+  // reset the auto incrementing id
+  await knex.raw('TRUNCATE TABLE recipes RESTART IDENTITY CASCADE')
+
   await knex('recipe_ingredients').del();
 
   // Inserts seed entries
@@ -44,10 +50,10 @@ export async function seed(knex: Knex): Promise<void> {
       instructions: JSON.stringify(['Add stone', 'Add water', 'Boil']),
     },
   ]);
-  // await knex('recipe_ingredients').insert([
-  //   { recipe_id: 1, ingredient_id: 1 },
-  //   { recipe_id: 1, ingredient_id: 2 },
-  //   { recipe_id: 1, ingredient_id: 3 },
-  //   { recipe_id: 1, ingredient_id: 4 },
-  // ]);
+  await knex('recipe_ingredients').insert([
+    { recipe_id: 1, ingredient_id: 1 },
+    { recipe_id: 1, ingredient_id: 2 },
+    { recipe_id: 1, ingredient_id: 3 },
+    { recipe_id: 1, ingredient_id: 4 },
+  ]);
 }


### PR DESCRIPTION
We have to force the incrementation to reset back to 1 in order for the IDs to be predictable (so we can seed the join table).